### PR TITLE
Add Case-Insensitive Search Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # nesoi-ts
 
 A micro-framework for quick development of distributed architectures with *NodeJS*, built on top of [adonisjs](https://github.com/adonisjs).
+
+### Query
+
+For more information: [Ransack Search Matchers](https://activerecord-hackery.github.io/ransack/getting-started/search-matches/)
+
+#### Available matchers
+
+- cont
+- i_cont
+- eq,
+- gteq,
+- lteq,
+- in


### PR DESCRIPTION
## Description

This PR introduces case-insensitive search functionality by adding a new operator `ilike` to the `QueryBuilder`. The `ilike` operator allows users to perform case-insensitive searches, which can be useful in scenarios where the case of the data being searched does not matter.

## Changes

1. **Operator Type Update:** The `Operator` type now includes `ilike` to recognize and handle `ilike` operations.
2. **OpRansackToRule Enum Update:** The `OpRansackToRule` enum has been updated to map the `i_cont` operator to `ilike`.
3. **Regular Expression Update:** The regular expression used to match rules has been updated to also match the `i_cont` operator.
4. **Value Formatting Update:** The code that formats the value for 'like' and 'ilike' operators has been updated to handle the `ilike` operator.
5. **Where Clause Handling Update:** The handling of the where clause in the `Query` class has been updated to handle the `ilike` operator.

## Impacts

The 'cont' operator was previously case-insensitive, but now it is case-sensitive. This means that if any application was previously relying on the case-insensitive nature of the 'cont' operator, it might now return different results. For example, a search for 'ABC' might not return results for 'abc', which could be misleading.
This change could also affect existing code that uses the 'cont' operator. If the code was written with the assumption that 'cont' is case-insensitive, it might need to be updated to handle the case-sensitive nature of the 'cont' operator.